### PR TITLE
"Do not allow dragging downwards to close if the first snap point is the active one and dismissible prop is set to false" had previously also prevented dragging upwards.

### DIFF
--- a/.changeset/blue-stingrays-sleep.md
+++ b/.changeset/blue-stingrays-sleep.md
@@ -1,0 +1,5 @@
+---
+"vaul-vue": patch
+---
+
+fix prevented dragging upwards.

--- a/.changeset/blue-stingrays-sleep.md
+++ b/.changeset/blue-stingrays-sleep.md
@@ -1,5 +1,0 @@
----
-"vaul-vue": patch
----
-
-fix prevented dragging upwards.

--- a/.changeset/curvy-sheep-pretend.md
+++ b/.changeset/curvy-sheep-pretend.md
@@ -1,0 +1,5 @@
+---
+"vaul-vue": patch
+---
+
+Allow for Upward Dragging in Scenario Involving Snap Points and Dismissible Prop

--- a/packages/vaul-vue/src/controls.ts
+++ b/packages/vaul-vue/src/controls.ts
@@ -274,7 +274,7 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
       const isDraggingDown = draggedDistance > 0
 
       // Disallow dragging down to close when first snap point is the active one and dismissible prop is set to false.
-      if (snapPoints.value && activeSnapPointIndex.value === 0 && !dismissible.value)
+      if (snapPoints.value && activeSnapPointIndex.value === 0 && !dismissible.value && !isDraggingDown)
         return
 
       if (!isAllowedToDrag.value && !shouldDrag(event.target, isDraggingDown))


### PR DESCRIPTION
The change now also checks the direction in which the pull is made so that it can still be pulled upwards.