### PR TITLE
fix: nested drawer does not trigger the parent drawer animation on close

### DIFF
--- a/.changeset/breezy-suns-cross.md
+++ b/.changeset/breezy-suns-cross.md
@@ -1,0 +1,5 @@
+---
+"vaul-vue": patch
+---
+
+Fixed nested drawer animation issue

--- a/packages/vaul-vue/src/controls.ts
+++ b/packages/vaul-vue/src/controls.ts
@@ -429,7 +429,7 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
     if (!drawerRef.value)
       return
 
-    // emitClose()
+    emitClose()
     set(drawerRef.value.$el, {
       transform: isVertical(direction.value)
         ? `translate3d(0, ${direction.value === 'bottom' ? '100%' : '-100%'}, 0)`


### PR DESCRIPTION
This change resolves #58