### PR TITLE
Bugfix, could not open middle snapping point while dragging upwards

### DIFF
--- a/packages/vaul-vue/src/useSnapPoints.ts
+++ b/packages/vaul-vue/src/useSnapPoints.ts
@@ -205,7 +205,7 @@ export function useSnapPoints({
       const dragDirection = hasDraggedUp ? 1 : -1 // 1 = up, -1 = down
 
       // Don't do anything if we swipe upwards while being on the last snap point
-      if (dragDirection > 0 && isLastSnapPoint) {
+      if (dragDirection > 0 && isLastSnapPoint.value) {
         snapToPoint(snapPointsOffset.value[(snapPoints.value?.length ?? 0) - 1])
         return
       }


### PR DESCRIPTION
When using multiple snap points and if not dragging very slowly its impossible to open the second index of snapping points, it will always go to the last index.

The issue is that when checking the computed property "isLastSnapPoint" when dragging upwards the if statement does not check the value of it, it only check the computed property itself which will evaluate to true. This fix simply check the value of the computed property instead and makes it work properly. 